### PR TITLE
Make Cosmos DB & SQL Pool Deployment Optional

### DIFF
--- a/docs/EnterpriseScaleAnalytics-AzureDevOpsDeployment.md
+++ b/docs/EnterpriseScaleAnalytics-AzureDevOpsDeployment.md
@@ -79,6 +79,7 @@ To begin, please open the [infra/params.dev.json](/infra/params.dev.json). In th
 | administratorPassword | Specifies the administrator password of the sql servers. Will be automatically set in the workflow. **Leave this value as is.** | `<your-secure-password>` |
 | processingService | Specifies the data engineering service that will be deployed (Data Factory or Synapse). | `dataFactory` or `synapse` |
 | synapseDefaultStorageAccountFileSystemId | Specifies the resource ID of the default storage account file system for Synapse. | `/subscriptions/{subscription-id}/resourceGroups/{rg-name}/providers/Microsoft.Storage/storageAccounts/{storage-name}/blobServices/default/containers/{container-name}` |
+| enableCosmos | Specifies whether Azure Cosmos DB should be deployed as part of the template. | `true` or `false` |
 | subnetId | Specifies the resource ID of the subnet to which all services will connect. | `/subscriptions/{subscription-id}/resourceGroups/{rg-name}/providers/Microsoft.Network/virtualNetworks/{vnet-name}/subnets/{subnet-name}` |
 | purviewId | Specifies the resource ID of the central Purview instance. | `/subscriptions/{subscription-id}/resourceGroups/{rg-name}/providers/Microsoft.Purview/accounts/{purview-name}` |
 | purviewManagedStorageId | Specifies the resource ID of the managed storage account of the central Purview instance. | `/subscriptions/{subscription-id}/resourceGroups/{rg-name}/providers/Microsoft.Storage/storageAccounts/{storage-account-name}` |

--- a/docs/EnterpriseScaleAnalytics-AzureDevOpsDeployment.md
+++ b/docs/EnterpriseScaleAnalytics-AzureDevOpsDeployment.md
@@ -79,12 +79,13 @@ To begin, please open the [infra/params.dev.json](/infra/params.dev.json). In th
 | administratorPassword | Specifies the administrator password of the sql servers. Will be automatically set in the workflow. **Leave this value as is.** | `<your-secure-password>` |
 | processingService | Specifies the data engineering service that will be deployed (Data Factory or Synapse). | `dataFactory` or `synapse` |
 | synapseDefaultStorageAccountFileSystemId | Specifies the resource ID of the default storage account file system for Synapse. | `/subscriptions/{subscription-id}/resourceGroups/{rg-name}/providers/Microsoft.Storage/storageAccounts/{storage-name}/blobServices/default/containers/{container-name}` |
+| enableSqlPool | Specifies whether an Azure SQL Pool should be deployed inside your Synapse workspace as part of the template. If you selected dataFactory as processingService, leave this value as is. | `true` or `false` |
 | enableCosmos | Specifies whether Azure Cosmos DB should be deployed as part of the template. | `true` or `false` |
 | subnetId | Specifies the resource ID of the subnet to which all services will connect. | `/subscriptions/{subscription-id}/resourceGroups/{rg-name}/providers/Microsoft.Network/virtualNetworks/{vnet-name}/subnets/{subnet-name}` |
 | purviewId | Specifies the resource ID of the central Purview instance. | `/subscriptions/{subscription-id}/resourceGroups/{rg-name}/providers/Microsoft.Purview/accounts/{purview-name}` |
 | purviewManagedStorageId | Specifies the resource ID of the managed storage account of the central Purview instance. | `/subscriptions/{subscription-id}/resourceGroups/{rg-name}/providers/Microsoft.Storage/storageAccounts/{storage-account-name}` |
 | purviewManagedEventHubId | Specifies the resource ID of the managed Event Hub of the central Purview instance. | `/subscriptions/{subscription-id}/resourceGroups/{rg-name}/providers/Microsoft.EventHub/namespaces/{eventhub-namespace-name}` |
-| enableRoleAssignments | Specifies whether role assignments should be enabled. **Leave this value as is.** | `true` or `false` |
+| enableRoleAssignments | Specifies whether role assignments should be enabled. | `true` or `false` |
 | privateDnsZoneIdKeyVault | Specifies the resource ID of the private DNS zone for KeyVault. | `/subscriptions/{subscription-id}/resourceGroups/{rg-name}/providers/Microsoft.Network/privateDnsZones/privatelink.vaultcore.azure.net` |
 | privateDnsZoneIdSynapseDev | Specifies the resource ID of the private DNS zone for Synapse Dev. | `/subscriptions/{subscription-id}/resourceGroups/{rg-name}/providers/Microsoft.Network/privateDnsZones/privatelink.dev.azuresynapse.net` |
 | privateDnsZoneIdSynapseSql | Specifies the resource ID of the private DNS zone for Synapse Sql. | `/subscriptions/{subscription-id}/resourceGroups/{rg-name}/providers/Microsoft.Network/privateDnsZones/privatelink.sql.azuresynapse.net` |

--- a/docs/EnterpriseScaleAnalytics-GitHubActionsDeployment.md
+++ b/docs/EnterpriseScaleAnalytics-GitHubActionsDeployment.md
@@ -70,6 +70,7 @@ To begin, please open the [infra/params.dev.json](/infra/params.dev.json). In th
 | administratorPassword | Specifies the administrator password of the sql servers. Will be automatically set in the workflow. **Leave this value as is.** | `<your-secure-password>` |
 | processingService | Specifies the data engineering service that will be deployed (Data Factory or Synapse). | `dataFactory` or `synapse` |
 | synapseDefaultStorageAccountFileSystemId | Specifies the resource ID of the default storage account file system for Synapse. | `/subscriptions/{subscription-id}/resourceGroups/{rg-name}/providers/Microsoft.Storage/storageAccounts/{storage-name}/blobServices/default/containers/{container-name}` |
+| enableCosmos | Specifies whether Azure Cosmos DB should be deployed as part of the template. | `true` or `false` |
 | subnetId | Specifies the resource ID of the subnet to which all services will connect. | `/subscriptions/{subscription-id}/resourceGroups/{rg-name}/providers/Microsoft.Network/virtualNetworks/{vnet-name}/subnets/{subnet-name}` |
 | purviewId | Specifies the resource ID of the central Purview instance. | `/subscriptions/{subscription-id}/resourceGroups/{rg-name}/providers/Microsoft.Purview/accounts/{purview-name}` |
 | purviewManagedStorageId | Specifies the resource ID of the managed storage account of the central Purview instance. | `/subscriptions/{subscription-id}/resourceGroups/{rg-name}/providers/Microsoft.Storage/storageAccounts/{storage-account-name}` |

--- a/docs/EnterpriseScaleAnalytics-GitHubActionsDeployment.md
+++ b/docs/EnterpriseScaleAnalytics-GitHubActionsDeployment.md
@@ -70,12 +70,13 @@ To begin, please open the [infra/params.dev.json](/infra/params.dev.json). In th
 | administratorPassword | Specifies the administrator password of the sql servers. Will be automatically set in the workflow. **Leave this value as is.** | `<your-secure-password>` |
 | processingService | Specifies the data engineering service that will be deployed (Data Factory or Synapse). | `dataFactory` or `synapse` |
 | synapseDefaultStorageAccountFileSystemId | Specifies the resource ID of the default storage account file system for Synapse. | `/subscriptions/{subscription-id}/resourceGroups/{rg-name}/providers/Microsoft.Storage/storageAccounts/{storage-name}/blobServices/default/containers/{container-name}` |
+| enableSqlPool | Specifies whether an Azure SQL Pool should be deployed inside your Synapse workspace as part of the template. If you selected dataFactory as processingService, leave this value as is. | `true` or `false` |
 | enableCosmos | Specifies whether Azure Cosmos DB should be deployed as part of the template. | `true` or `false` |
 | subnetId | Specifies the resource ID of the subnet to which all services will connect. | `/subscriptions/{subscription-id}/resourceGroups/{rg-name}/providers/Microsoft.Network/virtualNetworks/{vnet-name}/subnets/{subnet-name}` |
 | purviewId | Specifies the resource ID of the central Purview instance. | `/subscriptions/{subscription-id}/resourceGroups/{rg-name}/providers/Microsoft.Purview/accounts/{purview-name}` |
 | purviewManagedStorageId | Specifies the resource ID of the managed storage account of the central Purview instance. | `/subscriptions/{subscription-id}/resourceGroups/{rg-name}/providers/Microsoft.Storage/storageAccounts/{storage-account-name}` |
 | purviewManagedEventHubId | Specifies the resource ID of the managed Event Hub of the central Purview instance. | `/subscriptions/{subscription-id}/resourceGroups/{rg-name}/providers/Microsoft.EventHub/namespaces/{eventhub-namespace-name}` |
-| enableRoleAssignments | Specifies whether role assignments should be enabled. **Leave this value as is.** | `true` or `false` |
+| enableRoleAssignments | Specifies whether role assignments should be enabled. | `true` or `false` |
 | privateDnsZoneIdKeyVault | Specifies the resource ID of the private DNS zone for KeyVault. | `/subscriptions/{subscription-id}/resourceGroups/{rg-name}/providers/Microsoft.Network/privateDnsZones/privatelink.vaultcore.azure.net` |
 | privateDnsZoneIdSynapseDev | Specifies the resource ID of the private DNS zone for Synapse Dev. | `/subscriptions/{subscription-id}/resourceGroups/{rg-name}/providers/Microsoft.Network/privateDnsZones/privatelink.dev.azuresynapse.net` |
 | privateDnsZoneIdSynapseSql | Specifies the resource ID of the private DNS zone for Synapse Sql. | `/subscriptions/{subscription-id}/resourceGroups/{rg-name}/providers/Microsoft.Network/privateDnsZones/privatelink.sql.azuresynapse.net` |

--- a/docs/EnterpriseScaleAnalytics-Prerequisites.md
+++ b/docs/EnterpriseScaleAnalytics-Prerequisites.md
@@ -18,16 +18,16 @@ By navigating through the deployment steps, you will deploy the folowing setup i
 The deployment and code artifacts include the following services:
 
 - [Key Vault](https://docs.microsoft.com/azure/key-vault/general)
-- [Data Factory](https://docs.microsoft.com/azure/data-factory/)
-- [Cosmos DB](https://docs.microsoft.com/azure/cosmos-db/introduction)
-- [Synapse Workspace](https://docs.microsoft.com/azure/synapse-analytics/)
-- [MySQL Database](https://docs.microsoft.com/azure/mysql/overview)
-- [Azure SQL Database](https://docs.microsoft.com/azure/azure-sql/database/)
-- [PostgreSQL Database](https://docs.microsoft.com/azure/postgresql/)
-- [MariaDB Database](https://docs.microsoft.com/azure/mariadb/)
-- [SQL Pool](https://docs.microsoft.com/azure/synapse-analytics/sql-data-warehouse/sql-data-warehouse-overview-what-is)
-- [SQL Server](https://docs.microsoft.com/sql/sql-server/?view=sql-server-ver15)
-- [SQL Elastic Pool](https://docs.microsoft.com/azure/azure-sql/database/elastic-pool-overview)
+- [Data Factory](https://docs.microsoft.com/azure/data-factory/) (select between Data Factory and Synapse)
+- [Cosmos DB](https://docs.microsoft.com/azure/cosmos-db/introduction) (optional)
+- [Synapse Workspace](https://docs.microsoft.com/azure/synapse-analytics/) (select between Data Factory and Synapse)
+- [MySQL Database](https://docs.microsoft.com/azure/mysql/overview) (optional)
+- [Azure SQL Database](https://docs.microsoft.com/azure/azure-sql/database/) (optional)
+- [PostgreSQL Database](https://docs.microsoft.com/azure/postgresql/) (optional)
+- [MariaDB Database](https://docs.microsoft.com/azure/mariadb/) (optional)
+- [SQL Pool](https://docs.microsoft.com/azure/synapse-analytics/sql-data-warehouse/sql-data-warehouse-overview-what-is) (optional)
+- [SQL Server](https://docs.microsoft.com/sql/sql-server/?view=sql-server-ver15) (optional)
+- [SQL Elastic Pool](https://docs.microsoft.com/azure/azure-sql/database/elastic-pool-overview) (optional)
 - [BigData Pool](https://docs.microsoft.com/sql/big-data-cluster/concept-data-pool?view=sql-server-ver15)
 
 ## Code Structure

--- a/docs/reference/portal.dataProduct.json
+++ b/docs/reference/portal.dataProduct.json
@@ -554,6 +554,18 @@
                                     "osPlatform": "Windows"
                                 },
                                 {
+                                    "name": "enableCosmos",
+                                    "label": "Enable Azure Cosmos DB",
+                                    "type": "Microsoft.Common.CheckBox",
+                                    "visible": true,
+                                    "defaultValue": false,
+                                    "toolTip": "Enable the deployment of Azure Cosmos DB.",
+                                    "constraints": {
+                                        "required": false,
+                                        "validationMessage": "Enable the deployment of Azure Cosmos DB."
+                                    }
+                                },
+                                {
                                     "name": "infoBoxRoleAssignment",
                                     "type": "Microsoft.Common.InfoBox",
                                     "visible": true,
@@ -957,6 +969,7 @@
                 "administratorPassword": "[if(empty(steps('generalSettings').generalSettings.administratorPassword.password), '', steps('generalSettings').generalSettings.administratorPassword.password)]",
                 "processingService": "[if(empty(steps('generalSettings').dataProcessingServiceDeploymentSettings.processingService), '', steps('generalSettings').dataProcessingServiceDeploymentSettings.processingService)]",
                 "synapseDefaultStorageAccountFileSystemId": "[if(empty(steps('generalSettings').dataProcessingServiceDeploymentSettings.synapseDefaultStorageAccountFileSystemId), '', steps('generalSettings').dataProcessingServiceDeploymentSettings.synapseDefaultStorageAccountFileSystemId)]",
+                "enableCosmos": "[steps('generalSettings').generalSettings.enableCosmos]",
                 "purviewId": "[if(empty(steps('generalSettings').dataGovernanceSettings.purviewId.id), '', steps('generalSettings').dataGovernanceSettings.purviewId.id)]",
                 "purviewManagedStorageId": "[if(empty(steps('generalSettings').dataGovernanceSettings.purviewId.id), '', steps('generalSettings').dataGovernanceSettings.purviewApi.properties.managedResources.storageAccount)]",
                 "purviewManagedEventHubId": "[if(empty(steps('generalSettings').dataGovernanceSettings.purviewId.id), '', steps('generalSettings').dataGovernanceSettings.purviewApi.properties.managedResources.eventHubNamespace)]",

--- a/docs/reference/portal.dataProduct.json
+++ b/docs/reference/portal.dataProduct.json
@@ -429,6 +429,18 @@
                                         "allowedValues": "[map(steps('generalSettings').dataProcessingServiceDeploymentSettings.synapseDefaultStorageAccountFileSystemApi.value, (item) => parse(concat('{\"label\":\"', item.name, '\",\"value\":\"', item.id, '\"}')))]",
                                         "required": true
                                     }
+                                },
+                                {
+                                    "name": "enableSqlPool",
+                                    "label": "Enable SQL Pool",
+                                    "type": "Microsoft.Common.CheckBox",
+                                    "visible": "[equals(steps('generalSettings').dataProcessingServiceDeploymentSettings.processingService, 'synapse')]",
+                                    "defaultValue": false,
+                                    "toolTip": "Enable the deployment of an Azure SQL Pool (DW100).",
+                                    "constraints": {
+                                        "required": false,
+                                        "validationMessage": "Enable the deployment of an Azure SQL Pool (DW100)."
+                                    }
                                 }
                             ]
                         },
@@ -969,6 +981,7 @@
                 "administratorPassword": "[if(empty(steps('generalSettings').generalSettings.administratorPassword.password), '', steps('generalSettings').generalSettings.administratorPassword.password)]",
                 "processingService": "[if(empty(steps('generalSettings').dataProcessingServiceDeploymentSettings.processingService), '', steps('generalSettings').dataProcessingServiceDeploymentSettings.processingService)]",
                 "synapseDefaultStorageAccountFileSystemId": "[if(empty(steps('generalSettings').dataProcessingServiceDeploymentSettings.synapseDefaultStorageAccountFileSystemId), '', steps('generalSettings').dataProcessingServiceDeploymentSettings.synapseDefaultStorageAccountFileSystemId)]",
+                "enableSqlPool": "[steps('generalSettings').dataProcessingServiceDeploymentSettings.enableSqlPool]",
                 "enableCosmos": "[steps('generalSettings').generalSettings.enableCosmos]",
                 "purviewId": "[if(empty(steps('generalSettings').dataGovernanceSettings.purviewId.id), '', steps('generalSettings').dataGovernanceSettings.purviewId.id)]",
                 "purviewManagedStorageId": "[if(empty(steps('generalSettings').dataGovernanceSettings.purviewId.id), '', steps('generalSettings').dataGovernanceSettings.purviewApi.properties.managedResources.storageAccount)]",

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -41,6 +41,8 @@ param administratorPassword string = ''
 param processingService string = 'dataFactory'
 @description('Specifies the resource ID of the default storage account file system for Synapse. If you selected dataFactory as processingService, leave this value empty as is.')
 param synapseDefaultStorageAccountFileSystemId string = ''
+@description('Specifies whether Azure Cosmos DB should be deployed as part of the template.')
+param enableCosmos bool = false
 @description('Specifies the resource ID of the central Purview instance.')
 param purviewId string = ''
 @description('Specifies the resource ID of the managed storage account of the central Purview instance.')
@@ -157,7 +159,7 @@ module datafactory001 'modules/services/datafactory.bicep' = if (processingServi
   }
 }
 
-module cosmosdb001 'modules/services/cosmosdb.bicep' = {
+module cosmosdb001 'modules/services/cosmosdb.bicep' = if(enableCosmos) {
   name: 'cosmos001'
   scope: resourceGroup()
   params: {

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -41,6 +41,8 @@ param administratorPassword string = ''
 param processingService string = 'dataFactory'
 @description('Specifies the resource ID of the default storage account file system for Synapse. If you selected dataFactory as processingService, leave this value empty as is.')
 param synapseDefaultStorageAccountFileSystemId string = ''
+@description('Specifies whether an Azure SQL Pool should be deployed inside your Synapse workspace as part of the template. If you selected dataFactory as processingService, leave this value as is.')
+param enableSqlPool bool = false
 @description('Specifies whether Azure Cosmos DB should be deployed as part of the template.')
 param enableCosmos bool = false
 @description('Specifies the resource ID of the central Purview instance.')
@@ -128,6 +130,7 @@ module synapse001 'modules/services/synapse.bicep' = if (processingService == 's
     privateDnsZoneIdSynapseDev: privateDnsZoneIdSynapseDev
     privateDnsZoneIdSynapseSql: privateDnsZoneIdSynapseSql
     purviewId: purviewId
+    enableSqlPool: enableSqlPool
     synapseComputeSubnetId: ''
     synapseDefaultStorageAccountFileSystemId: synapseDefaultStorageAccountFileSystemId
   }

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -232,3 +232,5 @@ module postgresql001 'modules/services/postgresql.bicep' = if (sqlFlavour == 'po
     privateDnsZoneIdPostgreSql: privateDnsZoneIdPostgreSql
   }
 }
+
+// Outputs

--- a/infra/main.json
+++ b/infra/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.4.1008.15138",
-      "templateHash": "18378748460188709613"
+      "templateHash": "14955608285116165620"
     }
   },
   "parameters": {
@@ -78,6 +78,13 @@
       "defaultValue": "",
       "metadata": {
         "description": "Specifies the resource ID of the default storage account file system for Synapse. If you selected dataFactory as processingService, leave this value empty as is."
+      }
+    },
+    "enableCosmos": {
+      "type": "bool",
+      "defaultValue": false,
+      "metadata": {
+        "description": "Specifies whether Azure Cosmos DB should be deployed as part of the template."
       }
     },
     "purviewId": {
@@ -1141,6 +1148,7 @@
       ]
     },
     {
+      "condition": "[parameters('enableCosmos')]",
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2020-06-01",
       "name": "cosmos001",

--- a/infra/main.json
+++ b/infra/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.4.1008.15138",
-      "templateHash": "14955608285116165620"
+      "templateHash": "16668218448038666314"
     }
   },
   "parameters": {
@@ -78,6 +78,13 @@
       "defaultValue": "",
       "metadata": {
         "description": "Specifies the resource ID of the default storage account file system for Synapse. If you selected dataFactory as processingService, leave this value empty as is."
+      }
+    },
+    "enableSqlPool": {
+      "type": "bool",
+      "defaultValue": false,
+      "metadata": {
+        "description": "Specifies whether an Azure SQL Pool should be deployed inside your Synapse workspace as part of the template. If you selected dataFactory as processingService, leave this value as is."
       }
     },
     "enableCosmos": {
@@ -405,6 +412,9 @@
           "purviewId": {
             "value": "[parameters('purviewId')]"
           },
+          "enableSqlPool": {
+            "value": "[parameters('enableSqlPool')]"
+          },
           "synapseComputeSubnetId": {
             "value": ""
           },
@@ -419,7 +429,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.4.1008.15138",
-              "templateHash": "12939980671520056012"
+              "templateHash": "10342313127646962347"
             }
           },
           "parameters": {
@@ -468,6 +478,10 @@
             "purviewId": {
               "type": "string",
               "defaultValue": ""
+            },
+            "enableSqlPool": {
+              "type": "bool",
+              "defaultValue": false
             }
           },
           "functions": [],
@@ -512,6 +526,7 @@
               }
             },
             {
+              "condition": "[parameters('enableSqlPool')]",
               "type": "Microsoft.Synapse/workspaces/sqlPools",
               "apiVersion": "2021-03-01",
               "name": "[format('{0}/{1}', parameters('synapseName'), 'sqlPool001')]",

--- a/infra/modules/services/synapse.bicep
+++ b/infra/modules/services/synapse.bicep
@@ -19,6 +19,7 @@ param synapseComputeSubnetId string = ''
 param privateDnsZoneIdSynapseSql string = ''
 param privateDnsZoneIdSynapseDev string = ''
 param purviewId string = ''
+param enableSqlPool bool = false
 
 // Variables
 var synapseDefaultStorageAccountFileSystemName = length(split(synapseDefaultStorageAccountFileSystemId, '/')) >= 13 ? last(split(synapseDefaultStorageAccountFileSystemId, '/')) : 'incorrectSegmentLength'
@@ -59,7 +60,7 @@ resource synapse 'Microsoft.Synapse/workspaces@2021-03-01' = {
   }
 }
 
-resource synapseSqlPool001 'Microsoft.Synapse/workspaces/sqlPools@2021-03-01' = {
+resource synapseSqlPool001 'Microsoft.Synapse/workspaces/sqlPools@2021-03-01' = if(enableSqlPool) {
   parent: synapse
   name: 'sqlPool001'
   location: location

--- a/infra/params.dev.json
+++ b/infra/params.dev.json
@@ -26,6 +26,9 @@
         "synapseDefaultStorageAccountFileSystemId": {
             "value": "/subscriptions/2150d511-458f-43b9-8691-6819ba2e6c7b/resourceGroups/dlz01-dev-storage/providers/Microsoft.Storage/storageAccounts/dlz01devencur/blobServices/default/containers/di001"
         },
+        "enableSqlPool": {
+            "value": true
+        },
         "enableCosmos": {
             "value": true
         },

--- a/infra/params.dev.json
+++ b/infra/params.dev.json
@@ -26,6 +26,9 @@
         "synapseDefaultStorageAccountFileSystemId": {
             "value": "/subscriptions/2150d511-458f-43b9-8691-6819ba2e6c7b/resourceGroups/dlz01-dev-storage/providers/Microsoft.Storage/storageAccounts/dlz01devencur/blobServices/default/containers/di001"
         },
+        "enableCosmos": {
+            "value": true
+        },
         "subnetId": {
             "value": "/subscriptions/2150d511-458f-43b9-8691-6819ba2e6c7b/resourceGroups/dlz01-dev-network/providers/Microsoft.Network/virtualNetworks/dlz01-dev-vnet/subnets/DataIntegration001Subnet"
         },

--- a/infra/params.prod.json
+++ b/infra/params.prod.json
@@ -26,6 +26,9 @@
         "synapseDefaultStorageAccountFileSystemId": {
             "value": "/subscriptions/2150d511-458f-43b9-8691-6819ba2e6c7b/resourceGroups/dlz01-prd-storage/providers/Microsoft.Storage/storageAccounts/dlz01devwork/blobServices/default/containers/di001"
         },
+        "enableSqlPool": {
+            "value": true
+        },
         "enableCosmos": {
             "value": true
         },

--- a/infra/params.prod.json
+++ b/infra/params.prod.json
@@ -26,6 +26,9 @@
         "synapseDefaultStorageAccountFileSystemId": {
             "value": "/subscriptions/2150d511-458f-43b9-8691-6819ba2e6c7b/resourceGroups/dlz01-prd-storage/providers/Microsoft.Storage/storageAccounts/dlz01devwork/blobServices/default/containers/di001"
         },
+        "enableCosmos": {
+            "value": true
+        },
         "subnetId": {
             "value": "/subscriptions/2150d511-458f-43b9-8691-6819ba2e6c7b/resourceGroups/dlz01-prd-network/providers/Microsoft.Network/virtualNetworks/dlz01-prd-vnet/subnets/DataIntegration001Subnet"
         },

--- a/infra/params.test.json
+++ b/infra/params.test.json
@@ -26,6 +26,9 @@
         "synapseDefaultStorageAccountFileSystemId": {
             "value": "/subscriptions/2150d511-458f-43b9-8691-6819ba2e6c7b/resourceGroups/dlz01-tst-storage/providers/Microsoft.Storage/storageAccounts/dlz01devwork/blobServices/default/containers/di001"
         },
+        "enableSqlPool": {
+            "value": true
+        },
         "enableCosmos": {
             "value": true
         },

--- a/infra/params.test.json
+++ b/infra/params.test.json
@@ -26,6 +26,9 @@
         "synapseDefaultStorageAccountFileSystemId": {
             "value": "/subscriptions/2150d511-458f-43b9-8691-6819ba2e6c7b/resourceGroups/dlz01-tst-storage/providers/Microsoft.Storage/storageAccounts/dlz01devwork/blobServices/default/containers/di001"
         },
+        "enableCosmos": {
+            "value": true
+        },
         "subnetId": {
             "value": "/subscriptions/2150d511-458f-43b9-8691-6819ba2e6c7b/resourceGroups/dlz01-tst-network/providers/Microsoft.Network/virtualNetworks/dlz01-tst-vnet/subnets/DataIntegration001Subnet"
         },


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes. 
-->

**This PR fixes**
This PR will make the deployment of Azure Cosmos DB optional. Users can control via input parameter or checkbox in the portal, whether they want to deploy Cosmos DB as part of the Data Product deployment. Default option in the Portal is false.