### PR TITLE
Update portal.dataProduct.json

### DIFF
--- a/docs/reference/portal.dataProduct.json
+++ b/docs/reference/portal.dataProduct.json
@@ -85,7 +85,7 @@
                                     "type": "Microsoft.Common.InfoBox",
                                     "visible": true,
                                     "options": {
-                                        "text": "We have already deployed a few resourge groups in your Data Landing Zone, which can be used for Data Product and Data Integration Template deployments. They have the following names: '{prefix}-dp001', '{prefix}-dp002', '{prefix}-di001' and '{prefix}-di002'.",
+                                        "text": "We have already deployed a few resource groups in your Data Landing Zone, which can be used for Data Product and Data Integration Template deployments. They have the following names: '{prefix}-dp001', '{prefix}-dp002', '{prefix}-di001' and '{prefix}-di002'.",
                                         "style": "Info"
                                     }
                                 },


### PR DESCRIPTION
fixed a typo: from "resourge" to "resource"

<!-- Thank you for submitting a Pull Request. Please: 
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes. 
-->

**This PR fixes**
There is a note on this template that states:
"We have already deployed a few resourge groups in your Data Landing Zone, which can be used for Data Product and Data Integration Template deployments. They have the following names: '{prefix}-dp001', '{prefix}-dp002', '{prefix}-di001' and '{prefix}-di002'."


I fixed the typo on the word "resourge" and changed it to "resource" on the first line of this paragraph.
